### PR TITLE
fix bugs

### DIFF
--- a/yolox/data/datasets/voc.py
+++ b/yolox/data/datasets/voc.py
@@ -144,7 +144,7 @@ class VOCDetection(Dataset):
 
         target = self.load_anno(index)
 
-        img_info = (width, height)
+        img_info = (height, width)
 
         return img, target, img_info, index
 

--- a/yolox/models/yolo_head.py
+++ b/yolox/models/yolo_head.py
@@ -205,7 +205,7 @@ class YOLOXHead(M.Module):
         n_ch = 5 + self.num_classes
         hsize, wsize = output.shape[-2:]
         if grid.shape[2:4] != output.shape[2:4]:
-            xv, yv = meshgrid(F.arange(hsize), F.arange(wsize))
+            xv, yv = meshgrid(F.arange(wsize), F.arange(hsize))
             grid = F.stack((xv, yv), 2).reshape(1, 1, hsize, wsize, 2)
             self.grids[k] = grid
 
@@ -223,7 +223,7 @@ class YOLOXHead(M.Module):
         grids = []
         strides = []
         for (hsize, wsize), stride in zip(self.hw, self.strides):
-            xv, yv = meshgrid(F.arange(hsize), F.arange(wsize))
+            xv, yv = meshgrid(F.arange(wsize), F.arange(hsize))
             grid = F.stack((xv, yv), 2).reshape(1, -1, 2)
             grids.append(grid)
             shape = grid.shape[:2]


### PR DESCRIPTION
1. `img_info` for VOC dataset is wrong.
2. `grid` for yolo_head is wrong (Similar to https://github.com/MegEngine/YOLOX/issues/9). If the image has the same height and width, it will be ok. But, when `height != weight`, it will be wrong.